### PR TITLE
Test extensions against development git-annex

### DIFF
--- a/.github/workflows/test-datalad_container.yaml
+++ b/.github/workflows/test-datalad_container.yaml
@@ -19,21 +19,37 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      matrix:
+        # name mimics the one in .travis.yml for datalad build introduced in
+        # https://github.com/datalad/datalad/pull/4640
+        annex-install-scenario: [neurodebian, datalad-extensions-latest]
       fail-fast: false
 
     steps:
+    - uses: actions/checkout@v1
     - name: Set up system
       shell: bash
       run: |
         bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install git-annex-standalone
+        case "${{ matrix.annex-install-scenario }}" in
+          neurodebian)
+            sudo eatmydata apt-get install git-annex-standalone
+            ;;
+          datalad-extensions-latest)
+            sudo eatmydata apt-get install jq
+            GITHUB_TOKEN=${{ secrets.datalad_github_token }} ./scripts/ci/download-latest-artifact
+            sudo eatmydata dpkg -i download/*.deb
+            ;;
+          *)
+            echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
+            exit 1
+        esac
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/test-datalad_crawler.yaml
+++ b/.github/workflows/test-datalad_crawler.yaml
@@ -19,21 +19,37 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      matrix:
+        # name mimics the one in .travis.yml for datalad build introduced in
+        # https://github.com/datalad/datalad/pull/4640
+        annex-install-scenario: [neurodebian, datalad-extensions-latest]
       fail-fast: false
 
     steps:
+    - uses: actions/checkout@v1
     - name: Set up system
       shell: bash
       run: |
         bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install git-annex-standalone
+        case "${{ matrix.annex-install-scenario }}" in
+          neurodebian)
+            sudo eatmydata apt-get install git-annex-standalone
+            ;;
+          datalad-extensions-latest)
+            sudo eatmydata apt-get install jq
+            GITHUB_TOKEN=${{ secrets.datalad_github_token }} ./scripts/ci/download-latest-artifact
+            sudo eatmydata dpkg -i download/*.deb
+            ;;
+          *)
+            echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
+            exit 1
+        esac
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/test-datalad_hirni.yaml
+++ b/.github/workflows/test-datalad_hirni.yaml
@@ -19,21 +19,37 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      matrix:
+        # name mimics the one in .travis.yml for datalad build introduced in
+        # https://github.com/datalad/datalad/pull/4640
+        annex-install-scenario: [neurodebian, datalad-extensions-latest]
       fail-fast: false
 
     steps:
+    - uses: actions/checkout@v1
     - name: Set up system
       shell: bash
       run: |
         bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install git-annex-standalone
+        case "${{ matrix.annex-install-scenario }}" in
+          neurodebian)
+            sudo eatmydata apt-get install git-annex-standalone
+            ;;
+          datalad-extensions-latest)
+            sudo eatmydata apt-get install jq
+            GITHUB_TOKEN=${{ secrets.datalad_github_token }} ./scripts/ci/download-latest-artifact
+            sudo eatmydata dpkg -i download/*.deb
+            ;;
+          *)
+            echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
+            exit 1
+        esac
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/test-datalad_neuroimaging.yaml
+++ b/.github/workflows/test-datalad_neuroimaging.yaml
@@ -19,21 +19,37 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      matrix:
+        # name mimics the one in .travis.yml for datalad build introduced in
+        # https://github.com/datalad/datalad/pull/4640
+        annex-install-scenario: [neurodebian, datalad-extensions-latest]
       fail-fast: false
 
     steps:
+    - uses: actions/checkout@v1
     - name: Set up system
       shell: bash
       run: |
         bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install git-annex-standalone
+        case "${{ matrix.annex-install-scenario }}" in
+          neurodebian)
+            sudo eatmydata apt-get install git-annex-standalone
+            ;;
+          datalad-extensions-latest)
+            sudo eatmydata apt-get install jq
+            GITHUB_TOKEN=${{ secrets.datalad_github_token }} ./scripts/ci/download-latest-artifact
+            sudo eatmydata dpkg -i download/*.deb
+            ;;
+          *)
+            echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
+            exit 1
+        esac
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/test-datalad_ukbiobank.yaml
+++ b/.github/workflows/test-datalad_ukbiobank.yaml
@@ -5,12 +5,11 @@ name: test-datalad_ukbiobank
 
 on:
   # Trigger the workflow on pull request,
-  # but only for the master branch
+  # but only if any given extension workflow was modified
   pull_request:
-    branches:
-      - master
     paths:
       - '.github/workflows/test-datalad_ukbiobank.yaml'
+  # all should be triggered on cron
   schedule:
     - cron: '30 01 * * *'
 
@@ -20,21 +19,37 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      matrix:
+        # name mimics the one in .travis.yml for datalad build introduced in
+        # https://github.com/datalad/datalad/pull/4640
+        annex-install-scenario: [neurodebian, datalad-extensions-latest]
       fail-fast: false
 
     steps:
+    - uses: actions/checkout@v1
     - name: Set up system
       shell: bash
       run: |
         bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install git-annex-standalone
+        case "${{ matrix.annex-install-scenario }}" in
+          neurodebian)
+            sudo eatmydata apt-get install git-annex-standalone
+            ;;
+          datalad-extensions-latest)
+            sudo eatmydata apt-get install jq
+            GITHUB_TOKEN=${{ secrets.datalad_github_token }} ./scripts/ci/download-latest-artifact
+            sudo eatmydata dpkg -i download/*.deb
+            ;;
+          *)
+            echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
+            exit 1
+        esac
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/test-datalad_webapp.yaml
+++ b/.github/workflows/test-datalad_webapp.yaml
@@ -19,21 +19,37 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      matrix:
+        # name mimics the one in .travis.yml for datalad build introduced in
+        # https://github.com/datalad/datalad/pull/4640
+        annex-install-scenario: [neurodebian, datalad-extensions-latest]
       fail-fast: false
 
     steps:
+    - uses: actions/checkout@v1
     - name: Set up system
       shell: bash
       run: |
         bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install git-annex-standalone
+        case "${{ matrix.annex-install-scenario }}" in
+          neurodebian)
+            sudo eatmydata apt-get install git-annex-standalone
+            ;;
+          datalad-extensions-latest)
+            sudo eatmydata apt-get install jq
+            GITHUB_TOKEN=${{ secrets.datalad_github_token }} ./scripts/ci/download-latest-artifact
+            sudo eatmydata dpkg -i download/*.deb
+            ;;
+          *)
+            echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
+            exit 1
+        esac
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/scripts/ci/download-latest-artifact
+++ b/scripts/ci/download-latest-artifact
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Based on https://raw.githubusercontent.com/RedHatInsights/policies-ui-frontend/master/.github/scripts/download-latest-openapi.sh
+# Apache 2.0 license 
+set -eu
+
+: "${TARGET_REPO:=datalad/datalad-extensions}"
+: "${TARGET_BRANCH:=master}"
+: "${TARGET_WORKFLOW:=build-git-annex-debianstandalone.yaml}"
+: "${TARGET_PATH:=download}"  # Directory which will be created if doesn't exist
+: "${GITHUB_TOKEN}" # needs to be defined
+
+: "${CURL:=curl --silent}"
+
+: "${JOBS_DOWNLOAD:=$(mktemp -u)}"
+
+function definedOrExit {
+  if [[ -z "$1" ]]; then
+    echo "$2"
+    cat "$3"
+    exit 1
+  fi
+}
+
+echo "Using curl as \"${CURL}\""
+
+function call_curl {
+  ${CURL} -H "Authorization: Bearer ${GITHUB_TOKEN}" "$@"
+}
+
+JOBS_URL="https://api.github.com/repos/${TARGET_REPO}/actions/workflows/${TARGET_WORKFLOW}/runs?status=success&branch=${TARGET_BRANCH}"
+
+echo "Getting artifacts_url from ${JOBS_URL} into ${JOBS_DOWNLOAD}"
+call_curl "${JOBS_URL}" >| "${JOBS_DOWNLOAD}"
+ARTIFACTS_URL=$(jq --raw-output '.workflow_runs[0].artifacts_url | if . == null then "" else . end' < "${JOBS_DOWNLOAD}")
+definedOrExit "${ARTIFACTS_URL}" "Unable to get artifacts_url" ${JOBS_DOWNLOAD}
+
+echo "Getting archive download url from ${ARTIFACTS_URL}"
+call_curl "${ARTIFACTS_URL}" >| ${JOBS_DOWNLOAD}
+ARCHIVE_DOWNLOAD_URL=$(jq --raw-output '.artifacts[0].archive_download_url | if . == null then "" else . end' < ${JOBS_DOWNLOAD})
+definedOrExit "${ARCHIVE_DOWNLOAD_URL}" "Unable to get archive_download_url" ${JOBS_DOWNLOAD}
+
+call_curl -i "${ARCHIVE_DOWNLOAD_URL}" >| ${JOBS_DOWNLOAD}
+echo "Getting download url from ${ARCHIVE_DOWNLOAD_URL}"
+DOWNLOAD_URL=$(grep -oP 'Location: \K.+' < ${JOBS_DOWNLOAD})
+definedOrExit "${DOWNLOAD_URL}" "Unable to get Location header with download url" ${JOBS_DOWNLOAD}
+DOWNLOAD_URL=${DOWNLOAD_URL%$'\r'}
+rm -f ${JOBS_DOWNLOAD}
+
+echo "Downloading artifact package from ${DOWNLOAD_URL}"
+mkdir -p "${TARGET_PATH}"
+call_curl "${DOWNLOAD_URL}" >| ${TARGET_PATH}/.artifact.zip
+( cd "${TARGET_PATH}" && unzip .artifact.zip; )
+rm ${TARGET_PATH}/.artifact.zip

--- a/templates/.github/workflows/test-{{extension.name}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}.yaml
@@ -22,29 +22,34 @@ jobs:
       matrix:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
-        annex-install-scenario: [neurodebian]
+        annex-install-scenario: [neurodebian, datalad-extensions-latest]
       fail-fast: false
 
     steps:
+    - uses: actions/checkout@v1
     - name: Set up system
       shell: bash
       run: |
+        bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+        sudo apt-get update -qq
+        sudo apt-get install eatmydata
         case "${{ matrix.annex-install-scenario }}" in
           neurodebian)
-            bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-            sudo apt-get update -qq
-            sudo apt-get install eatmydata
             sudo eatmydata apt-get install git-annex-standalone
             ;;
-        *)
-          echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
-          exit 1
+          datalad-extensions-latest)
+            sudo eatmydata apt-get install jq
+            GITHUB_TOKEN=${{ secrets.datalad_github_token }} ./scripts/ci/download-latest-artifact
+            sudo eatmydata dpkg -i download/*.deb
+            ;;
+          *)
+            echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
+            exit 1
         esac
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/templates/.github/workflows/test-{{extension.name}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}.yaml
@@ -19,16 +19,27 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      matrix:
+        # name mimics the one in .travis.yml for datalad build introduced in
+        # https://github.com/datalad/datalad/pull/4640
+        annex-install-scenario: [neurodebian]
       fail-fast: false
 
     steps:
     - name: Set up system
       shell: bash
       run: |
-        bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-        sudo apt-get update -qq
-        sudo apt-get install eatmydata
-        sudo eatmydata apt-get install git-annex-standalone
+        case "${{ matrix.annex-install-scenario }}" in
+          neurodebian)
+            bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+            sudo apt-get update -qq
+            sudo apt-get install eatmydata
+            sudo eatmydata apt-get install git-annex-standalone
+            ;;
+        *)
+          echo "Unknown scenario ${{ matrix.annex-install-scenario }}" >&2
+          exit 1
+        esac
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"


### PR DESCRIPTION
Replacement for #17 filed from a local branch to gain access to the secret.

It is not officially supported to download artifacts from another workflow but workarounds to be tested are provided eg in
https://github.com/actions/download-artifact/issues/3

- [x] introduce matrix in extensions testing template on what annex to install
- [x] add a matrix run `datalad-extensions-latest` for annex install scenario
- [ ] test across all extensions
- Later - enhance  install helper being introduced in https://github.com/datalad/datalad/pull/4640/files#diff-310e23a98b20f6aa856982181d5f4fa6 to add ability to install the most recent (or specified?) artifact build in here, and reuse that script here instead of custom duplicate code