### PR TITLE
RF: build git-annex debian package with DEB_BUILD_OPTIONS=nocheck 

### DIFF
--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Building it all
       run: |
-        scripts/ci/build_git_annex /tmp/annex-build
+        DEB_BUILD_OPTIONS=nocheck scripts/ci/build_git_annex /tmp/annex-build
 
     - name: Cleanup before bundling upload
       run: find /tmp/annex-build -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 rm -rf

--- a/scripts/ci/build_git_annex
+++ b/scripts/ci/build_git_annex
@@ -71,7 +71,11 @@ if ! singularity exec ./buildenv.sif \
        exit 1
 fi
 
-echo "I: Checking that all tests were ran and passed:"
-grep -E '^All [[:digit:]]{3} tests passed' "${bbuild_log}"
+if [[ "${DEB_BUILD_OPTIONS:-}" =~ nocheck ]]; then
+    echo "I: DEB_BUILD_OPTIONS=$DEB_BUILD_OPTIONS , so not checking that all tests were ran and passed"
+else
+    echo "I: Checking that all tests were ran and passed:"
+    grep -E '^All [[:digit:]]{3} tests passed' "${bbuild_log}"
+fi
 
 echo "I: Build finished. Log of binary build is $bbuild_log"


### PR DESCRIPTION
I have added it on top of the scripts/ci/build_git_annex assuming that singularity would pass
it inside (we do not do exec in isolation).  I did not want to modify build_git_annex
itself since typically we do not want to run the tests during pkg build time, and
it is specific to the workflow to skip them since follow up tests will run anyways

Follow up on discussion in https://github.com/datalad/datalad-extensions/issues/21

- [x] verify that tests were no ran actually.  I have not spotted any 'nocheck' handling in debian/rules so hope for the dh magic