### PR TITLE
ENH: test that there is no excessive failed lookups for libcpre location for git-annex

### DIFF
--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -26,7 +26,7 @@ jobs:
         bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install singularity-container gnupg moreutils
+        sudo eatmydata apt-get install singularity-container gnupg moreutils strace
 
     - name: Checkout this repository
       uses: actions/checkout@v1
@@ -105,6 +105,19 @@ jobs:
           export | grep -e crippledfs || :
 
           git annex test
+
+      - name: Run custom tests
+        run: |
+          mkdir /tmp/testrepo; cd /tmp/testrepo; git init
+          function nfailed() {
+            strace -f git-annex "$1" 2>&1 | awk "/$2.*ENOENT/{print}" | wc -l
+          }
+          # We should get some reasonable number (not 40) of directories look up for dynamic libraries
+          liblookups=
+          PS4='> '; set -x
+          test $(nfailed version "libpcre.*so") -lt 5
+          test $(nfailed init "libpcre.*so") -lt 20
+
 
   test-datalad:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -126,7 +126,7 @@ jobs:
         run: |
           mkdir /tmp/testrepo; cd /tmp/testrepo; git init
           function nfailed() {
-            strace -f git-annex "$1" 2>&1 | awk "/$2.*ENOENT/{print}" | wc -l
+            strace -f git-annex "$1" 2>&1 | awk "/$2.*ENOENT/{print}" | tee /dev/fd/2 | wc -l
           }
           # We should get some reasonable number (not 40) of directories look up for dynamic libraries
           liblookups=

--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -106,7 +106,23 @@ jobs:
 
           git annex test
 
-      - name: Run custom tests
+  test-annex-more:
+    runs-on: ubuntu-latest
+    needs: build-package
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Download git-annex package
+        uses: actions/download-artifact@v2-preview
+        with:
+          name: git-annex-debianstandalone-packages
+
+      - name: Install git-annex package
+        run: |
+          sudo dpkg -i git-annex*.deb
+
+      - name: Seek of dynlibs
         run: |
           mkdir /tmp/testrepo; cd /tmp/testrepo; git init
           function nfailed() {

--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -132,7 +132,7 @@ jobs:
           liblookups=
           PS4='> '; set -x
           test $(nfailed version "libpcre.*so") -lt 5
-          test $(nfailed init "libpcre.*so") -lt 20
+          test $(nfailed init "libpcre.*so") -lt 110
 
 
   test-datalad:

--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -132,7 +132,7 @@ jobs:
           liblookups=
           PS4='> '; set -x
           test $(nfailed version "libpcre.*so") -lt 5
-          test $(nfailed init "libpcre.*so") -lt 110
+          test $(nfailed init "libpcre.*so") -lt 130
 
 
   test-datalad:


### PR DESCRIPTION
I already forgot some other one I wanted to add, so decided to start  a PR where we would add more tests beyond what `git annex test` does to verify that all is good with the (standalone) build of git-annex.

Testing "git annex version" alone is suboptimal, since I would not be surprised
if git annex would just stop calling git for "git annex version" and we
would loose those. But testing any git annex operation (like init) ATM would
lead to many more of those, so added testing of "git annex init" to not have more than 20.

For more details:
see https://git-annex.branchable.com/todo/may_be___40__again__41___to_prelink_or_somehow_avoid_all_the_failing_opens__63__/

Wait for
- [x] standalone shims becoming a bit leaner or using prelink or smth. 