### PR TITLE
ENH: test-datalad: Enable SSH testing

### DIFF
--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -124,6 +124,15 @@ jobs:
         run: |
           sudo dpkg -i git-annex*.deb
 
+      - name: Set up SSH target
+        shell: bash
+        # TODO: Drop the release condition once 0.13.1 is released.
+        run: |
+          if [ "${{ matrix.version }}" != "release" ]; then
+            bash tools/ci/prep-travis-forssh.sh;
+            export DATALAD_TESTS_SSH=1;
+          fi
+
       - name: Set up environment
         run: |
           git config --global user.email "test@github.land"

--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -129,7 +129,10 @@ jobs:
         # TODO: Drop the release condition once 0.13.1 is released.
         run: |
           if [ "${{ matrix.version }}" != "release" ]; then
-            bash tools/ci/prep-travis-forssh.sh;
+            curl -fSsL \
+              https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
+              >setup-ssh.sh;
+            bash setup-ssh.sh;
             export DATALAD_TESTS_SSH=1;
           fi
 


### PR DESCRIPTION
Make use of the Docker SSH target that DataLad supports as of
datalad/datalad#4762.

Closes #19.

---

I suspect I'll at least need to enable docker in the workflow, but fingers crossed that this just works...