### PR TITLE
ENH: test-datalad: Enable SSH testing

### DIFF
--- a/.github/workflows/build-git-annex-debianstandalone.yaml
+++ b/.github/workflows/build-git-annex-debianstandalone.yaml
@@ -124,6 +124,17 @@ jobs:
         run: |
           sudo dpkg -i git-annex*.deb
 
+      - name: Set up SSH target
+        shell: bash
+        # TODO: Drop the release condition once 0.13.2 is released.
+        run: |
+          if [ "${{ matrix.version }}" != "release" ]; then
+            curl -fSsL \
+              https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
+              | bash;
+            echo "::set-env name=DATALAD_TESTS_SSH::1";
+          fi
+
       - name: Set up environment
         run: |
           git config --global user.email "test@github.land"


### PR DESCRIPTION
Make use of the Docker SSH target that DataLad supports as of
datalad/datalad#4762.

Closes #19.

---

Replaces #26.  As I say there, I suspect this won't work as is, and setting up the docker container will require more tweaking.
 