### PR TITLE
Use environment files instead of set-env and add-path

### DIFF
--- a/.github/workflows/build-git-annex.yaml
+++ b/.github/workflows/build-git-annex.yaml
@@ -127,7 +127,7 @@ jobs:
                   hdiutil attach git-annex.dmg
                   rsync -a /Volumes/git-annex/git-annex.app /Applications/
                   hdiutil detach /Volumes/git-annex/
-                  echo "::add-path::/Applications/git-annex.app/Contents/MacOS"
+                  echo /Applications/git-annex.app/Contents/MacOS >> $GITHUB_PATH
                   ;;
               *)
                   echo "Unknown OS ${{ runner.os }}"
@@ -218,7 +218,7 @@ jobs:
                   hdiutil attach git-annex.dmg
                   rsync -a /Volumes/git-annex/git-annex.app /Applications/
                   hdiutil detach /Volumes/git-annex/
-                  echo "::add-path::/Applications/git-annex.app/Contents/MacOS"
+                  echo /Applications/git-annex.app/Contents/MacOS >> $GITHUB_PATH
                   ;;
               *)
                   echo "Unknown OS ${{ runner.os }}"
@@ -273,7 +273,7 @@ jobs:
                   hdiutil attach git-annex.dmg
                   rsync -a /Volumes/git-annex/git-annex.app /Applications/
                   hdiutil detach /Volumes/git-annex/
-                  echo "::add-path::/Applications/git-annex.app/Contents/MacOS"
+                  echo /Applications/git-annex.app/Contents/MacOS >> $GITHUB_PATH
                   ;;
               *)
                   echo "Unknown OS ${{ runner.os }}"
@@ -295,7 +295,7 @@ jobs:
             curl -fSsL \
               https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
               | bash;
-            echo "::set-env name=DATALAD_TESTS_SSH::1";
+            echo DATALAD_TESTS_SSH=1 >> $GITHUB_ENV
           fi
 
       - name: Set up environment

--- a/.github/workflows/build-git-annex.yaml
+++ b/.github/workflows/build-git-annex.yaml
@@ -127,7 +127,7 @@ jobs:
                   hdiutil attach git-annex.dmg
                   rsync -a /Volumes/git-annex/git-annex.app /Applications/
                   hdiutil detach /Volumes/git-annex/
-                  echo /Applications/git-annex.app/Contents/MacOS >> $GITHUB_PATH
+                  echo /Applications/git-annex.app/Contents/MacOS >> "$GITHUB_PATH"
                   ;;
               *)
                   echo "Unknown OS ${{ runner.os }}"
@@ -218,7 +218,7 @@ jobs:
                   hdiutil attach git-annex.dmg
                   rsync -a /Volumes/git-annex/git-annex.app /Applications/
                   hdiutil detach /Volumes/git-annex/
-                  echo /Applications/git-annex.app/Contents/MacOS >> $GITHUB_PATH
+                  echo /Applications/git-annex.app/Contents/MacOS >> "$GITHUB_PATH"
                   ;;
               *)
                   echo "Unknown OS ${{ runner.os }}"
@@ -273,7 +273,7 @@ jobs:
                   hdiutil attach git-annex.dmg
                   rsync -a /Volumes/git-annex/git-annex.app /Applications/
                   hdiutil detach /Volumes/git-annex/
-                  echo /Applications/git-annex.app/Contents/MacOS >> $GITHUB_PATH
+                  echo /Applications/git-annex.app/Contents/MacOS >> "$GITHUB_PATH"
                   ;;
               *)
                   echo "Unknown OS ${{ runner.os }}"
@@ -295,7 +295,7 @@ jobs:
             curl -fSsL \
               https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
               | bash;
-            echo DATALAD_TESTS_SSH=1 >> $GITHUB_ENV
+            echo DATALAD_TESTS_SSH=1 >> "$GITHUB_ENV"
           fi
 
       - name: Set up environment


### PR DESCRIPTION
The set-env and add-path workflow commands are deprecated in favor of environment files: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/