### PR TITLE
Try setting "stack-no-global" on setup-haskell in git-annex on Windows workflow

### DIFF
--- a/.github/workflows/build-git-annex-windows.yaml
+++ b/.github/workflows/build-git-annex-windows.yaml
@@ -20,10 +20,10 @@ jobs:
     runs-on: windows-2016
     steps:
     - name: Setup Haskell
-      uses: actions/setup-haskell@v1.1
+      uses: actions/setup-haskell@v1.1.3
       with:
         enable-stack: true
-        ### TODO: Does adding "stack-no-global: true" here speed things up?
+        stack-no-global: true
 
     - name: Checkout this repository
       uses: actions/checkout@v1


### PR DESCRIPTION
I believe that adding this setting should reduce the runtime of the "Setup Haskell" stack by a minute or two while having no impact on the "stack setup" step.  If I am wrong, I will submit a separate PR to remove the TODO item from the workflow source.

Also upgrade setup-haskell in the hopes of eliminating warnings about add-path.