### PR TITLE
Test whether magic-haskell requires libmagic.dll or libmagic-1.dll to build

### DIFF
--- a/.github/workflows/build-git-annex-windows.yaml
+++ b/.github/workflows/build-git-annex-windows.yaml
@@ -48,8 +48,6 @@ jobs:
         GITHUB_TOKEN="${{ secrets.datalad_github_token }}"
         . "$GITHUB_WORKSPACE"/scripts/ci/download-latest-artifact
         cp download/* .
-        ### TODO: See if magic-haskell still builds without this line:
-        cp libmagic-1.dll libmagic.dll
       working-directory: git-annex
 
     - name: Enable building with magic

--- a/.github/workflows/build-git-annex-windows.yaml
+++ b/.github/workflows/build-git-annex-windows.yaml
@@ -48,6 +48,7 @@ jobs:
         GITHUB_TOKEN="${{ secrets.datalad_github_token }}"
         . "$GITHUB_WORKSPACE"/scripts/ci/download-latest-artifact
         cp download/* .
+        mv libmagic-1.dll libmagic.dll
       working-directory: git-annex
 
     - name: Enable building with magic

--- a/resources/git-annex-magicBundle.patch
+++ b/resources/git-annex-magicBundle.patch
@@ -9,7 +9,7 @@ index 096eeee29..4440cc980 100644
 +
 +magicDLLs :: [FilePath]
 +#ifdef mingw32_HOST_OS
-+magicDLLs = ["libmagic-1.dll", "libgnurx-0.dll"]
++magicDLLs = ["libmagic.dll", "libgnurx-0.dll"]
 +#else
 +magicDLLs = []
 +#endif


### PR DESCRIPTION
It doesn't make sense for magic-haskell to require `libmagic.dll` to build yet use `libmagic-1.dll` to run.  This PR tests whether getting rid of the former makes a difference.

If this PR fails, I will submit a separate PR to eliminate the TODO item from the workflow source (possibly after also checking whether running with `libmagic.dll` instead of `libmagic-1.dll` works).