### PR TITLE
Test whether git-annex on Windows requires libgnurx to run

### DIFF
--- a/.github/workflows/build-git-annex-windows.yaml
+++ b/.github/workflows/build-git-annex-windows.yaml
@@ -127,7 +127,7 @@ jobs:
         GIT_ANNEX_PATH="$(type -p git-annex)"
         echo "git-annex is at $GIT_ANNEX_PATH"
         GIT_ANNEX_DIR="$(dirname "$GIT_ANNEX_PATH")"
-        ls "$GIT_ANNEX_DIR"/*magic* "$GIT_ANNEX_DIR"/*gnurx*
+        ls "$GIT_ANNEX_DIR"/*magic*
         ls "$GIT_ANNEX_DIR"/../share/misc/*magic*
 
     - name: Check git-annex version for MagicMime flag

--- a/resources/git-annex-magicBundle.patch
+++ b/resources/git-annex-magicBundle.patch
@@ -9,7 +9,7 @@ index 096eeee29..4440cc980 100644
 +
 +magicDLLs :: [FilePath]
 +#ifdef mingw32_HOST_OS
-+magicDLLs = ["libmagic-1.dll", "libgnurx-0.dll"]
++magicDLLs = ["libmagic-1.dll"]
 +#else
 +magicDLLs = []
 +#endif


### PR DESCRIPTION
I think libgnurx might only be required for building file/libmagic and is afterwards unneeded.