### PR TITLE
Remove obsolete "TODO"

### DIFF
--- a/.github/workflows/build-git-annex-windows.yaml
+++ b/.github/workflows/build-git-annex-windows.yaml
@@ -48,7 +48,6 @@ jobs:
         GITHUB_TOKEN="${{ secrets.datalad_github_token }}"
         . "$GITHUB_WORKSPACE"/scripts/ci/download-latest-artifact
         cp download/* .
-        ### TODO: See if magic-haskell still builds without this line:
         cp libmagic-1.dll libmagic.dll
       working-directory: git-annex
 


### PR DESCRIPTION
Trying to address this to-do item didn't pan out (See #44), so it should be deleted from the workflow source.