### PR TITLE
Late fixes to tests of git-annex seems fixed it, removing || true

### DIFF
--- a/.github/workflows/build-git-annex-windows.yaml
+++ b/.github/workflows/build-git-annex-windows.yaml
@@ -159,4 +159,4 @@ jobs:
     - name: Run tests
       run: |
         cd $HOME
-        timeout 1800 git annex test || true
+        timeout 1800 git annex test


### PR DESCRIPTION
Ref: https://git-annex.branchable.com/bugs/storeKey_when_already_present_failures_on_Windows/?updated#comment-13d4a9dfd402b22d4746ae6a6adeb2e3