### PR TITLE
Match "Location:" header case-insensitively

### DIFF
--- a/scripts/ci/download-latest-artifact
+++ b/scripts/ci/download-latest-artifact
@@ -41,7 +41,7 @@ definedOrExit "${ARCHIVE_DOWNLOAD_URL}" "Unable to get archive_download_url" ${J
 
 call_curl -i "${ARCHIVE_DOWNLOAD_URL}" >| ${JOBS_DOWNLOAD}
 echo "Getting download url from ${ARCHIVE_DOWNLOAD_URL}"
-DOWNLOAD_URL=$(grep -oP 'Location: \K.+' < ${JOBS_DOWNLOAD})
+DOWNLOAD_URL=$(grep -ioP 'Location: \K.+' < ${JOBS_DOWNLOAD})
 definedOrExit "${DOWNLOAD_URL}" "Unable to get Location header with download url" ${JOBS_DOWNLOAD}
 DOWNLOAD_URL=${DOWNLOAD_URL%$'\r'}
 rm -f ${JOBS_DOWNLOAD}


### PR DESCRIPTION
Fixes #74; fixes #76.

Some change on GitHub's end has caused its server to return lowercase header field names in responses, and so `download-latest-artifact` was failing because it couldn't match "`Location: `".  This PR fixes that by making the match case-insensitive.