### PR TITLE
Don't be silent with curl so we see error

### DIFF
--- a/scripts/ci/download-latest-artifact
+++ b/scripts/ci/download-latest-artifact
@@ -9,7 +9,7 @@ set -eu
 : "${TARGET_PATH:=download}"  # Directory which will be created if doesn't exist
 : "${GITHUB_TOKEN}" # needs to be defined
 
-: "${CURL:=curl --silent}"
+: "${CURL:=curl}"
 
 : "${JOBS_DOWNLOAD:=$(mktemp -u)}"
 


### PR DESCRIPTION
I believe curl uses stderr for messages

Intention: see why download fails.

Anyways - we should switch to use datalad-installer