### PR TITLE
Workflow for committing to keep workflows active

### DIFF
--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -2,7 +2,7 @@ name: Commit to keep workflows active
 
 on:
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '00 12 * * *'
 
 jobs:
   heartbeat:
@@ -18,5 +18,10 @@ jobs:
 
       - name: Make & push an empty commit
         run: |
-          git commit --allow-empty -m '[EMPTY] Commit to keep workflows active'
-          git push
+          last_commit="$(git show -s --format=%at)"
+          cutoff="$(date --date='50 days ago' +%s)"
+          if [ "$last_commit" -lt "$cutoff" ]
+          then git commit --allow-empty -m '[EMPTY] Commit to keep workflows active'
+               git push
+          else echo 'Latest activity was within past 50 days; not committing'
+          fi

--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -1,0 +1,22 @@
+name: Commit to keep workflows active
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "heartbeat@github.nil"
+          git config --global user.name "Repository Heartbeat"
+
+      - name: Make & push an empty commit
+        run: |
+          git commit --allow-empty -m '[EMPTY] Commit to keep workflows active'
+          git push


### PR DESCRIPTION
Note: While I have no definitive reason to suspect this is the case, I wouldn't be surprised if it turns out that commits made via GitHub Actions workflows don't count towards "repository activity" for the purpose of keeping workflows active.