### PR TITLE
Update GitHub Actions action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[gh-actions]"
+      include: scope

--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure Git
         run: |

--- a/.github/workflows/test-datalad_catalog-maint.yaml
+++ b/.github/workflows/test-datalad_catalog-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_catalog-master.yaml
+++ b/.github/workflows/test-datalad_catalog-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_container-maint.yaml
+++ b/.github/workflows/test-datalad_container-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_container-master.yaml
+++ b/.github/workflows/test-datalad_container-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_crawler-maint.yaml
+++ b/.github/workflows/test-datalad_crawler-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_crawler-master.yaml
+++ b/.github/workflows/test-datalad_crawler-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_deprecated-maint.yaml
+++ b/.github/workflows/test-datalad_deprecated-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_deprecated-master.yaml
+++ b/.github/workflows/test-datalad_deprecated-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_fuse-maint.yaml
+++ b/.github/workflows/test-datalad_fuse-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_fuse-master.yaml
+++ b/.github/workflows/test-datalad_fuse-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_gooey-maint.yaml
+++ b/.github/workflows/test-datalad_gooey-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_gooey-master.yaml
+++ b/.github/workflows/test-datalad_gooey-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_metalad-maint.yaml
+++ b/.github/workflows/test-datalad_metalad-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_metalad-master.yaml
+++ b/.github/workflows/test-datalad_metalad-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_mihextras-maint.yaml
+++ b/.github/workflows/test-datalad_mihextras-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_mihextras-master.yaml
+++ b/.github/workflows/test-datalad_mihextras-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_neuroimaging-maint.yaml
+++ b/.github/workflows/test-datalad_neuroimaging-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_neuroimaging-master.yaml
+++ b/.github/workflows/test-datalad_neuroimaging-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_next-maint.yaml
+++ b/.github/workflows/test-datalad_next-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_next-master.yaml
+++ b/.github/workflows/test-datalad_next-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_osf-maint.yaml
+++ b/.github/workflows/test-datalad_osf-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_osf-master.yaml
+++ b/.github/workflows/test-datalad_osf-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_ukbiobank-maint.yaml
+++ b/.github/workflows/test-datalad_ukbiobank-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)

--- a/.github/workflows/test-datalad_ukbiobank-master.yaml
+++ b/.github/workflows/test-datalad_ukbiobank-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)

--- a/.github/workflows/test-datalad_xnat-maint.yaml
+++ b/.github/workflows/test-datalad_xnat-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (maint)
@@ -79,4 +79,4 @@ jobs:
         mkdir -p __testhome__
         cd __testhome__
 
-        python -m nose -s -v --with-cov --cover-package datalad datalad_xnat
+        python -m pytest -s -v  --cov=datalad --cov=datalad_xnat --pyargs datalad_xnat

--- a/.github/workflows/test-datalad_xnat-master.yaml
+++ b/.github/workflows/test-datalad_xnat-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad (master)
@@ -79,4 +79,4 @@ jobs:
         mkdir -p __testhome__
         cd __testhome__
 
-        python -m nose -s -v --with-cov --cover-package datalad datalad_xnat
+        python -m pytest -s -v  --cov=datalad --cov=datalad_xnat --pyargs datalad_xnat

--- a/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up system
       shell: bash
       run: |
@@ -56,7 +56,7 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install DataLad ({{ datalad_branch }})


### PR DESCRIPTION
We are currently using older versions of the updated GitHub Actions actions, and these older versions still use Node 12, [which is deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).