### PR TITLE
[DATALAD RUNCMD] boost checkout to v4

### DIFF
--- a/.github/workflows/heartbeat.yaml
+++ b/.github/workflows/heartbeat.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure Git
         run: |

--- a/.github/workflows/test-datalad_catalog-maint.yaml
+++ b/.github/workflows/test-datalad_catalog-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_catalog-master.yaml
+++ b/.github/workflows/test-datalad_catalog-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_container-maint.yaml
+++ b/.github/workflows/test-datalad_container-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_container-master.yaml
+++ b/.github/workflows/test-datalad_container-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_crawler-maint.yaml
+++ b/.github/workflows/test-datalad_crawler-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_crawler-master.yaml
+++ b/.github/workflows/test-datalad_crawler-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_dataverse-maint.yaml
+++ b/.github/workflows/test-datalad_dataverse-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_dataverse-master.yaml
+++ b/.github/workflows/test-datalad_dataverse-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_deprecated-maint.yaml
+++ b/.github/workflows/test-datalad_deprecated-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_deprecated-master.yaml
+++ b/.github/workflows/test-datalad_deprecated-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_fuse-maint.yaml
+++ b/.github/workflows/test-datalad_fuse-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_fuse-master.yaml
+++ b/.github/workflows/test-datalad_fuse-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_gooey-maint.yaml
+++ b/.github/workflows/test-datalad_gooey-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_gooey-master.yaml
+++ b/.github/workflows/test-datalad_gooey-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_metalad-maint.yaml
+++ b/.github/workflows/test-datalad_metalad-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_metalad-master.yaml
+++ b/.github/workflows/test-datalad_metalad-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_neuroimaging-maint.yaml
+++ b/.github/workflows/test-datalad_neuroimaging-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_neuroimaging-master.yaml
+++ b/.github/workflows/test-datalad_neuroimaging-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_next-maint.yaml
+++ b/.github/workflows/test-datalad_next-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_next-master.yaml
+++ b/.github/workflows/test-datalad_next-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_osf-maint.yaml
+++ b/.github/workflows/test-datalad_osf-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_osf-master.yaml
+++ b/.github/workflows/test-datalad_osf-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_ukbiobank-maint.yaml
+++ b/.github/workflows/test-datalad_ukbiobank-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_ukbiobank-master.yaml
+++ b/.github/workflows/test-datalad_ukbiobank-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_xnat-maint.yaml
+++ b/.github/workflows/test-datalad_xnat-maint.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/.github/workflows/test-datalad_xnat-master.yaml
+++ b/.github/workflows/test-datalad_xnat-master.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |

--- a/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up system
       shell: bash
       run: |


### PR DESCRIPTION
Replicating dependabot https://github.com/datalad/datalad-extensions/pull/118 which does not care about template and cannot test since is done from a fork
