### PR TITLE
Add testing against release of datalad-next

### DIFF
--- a/.github/workflows/test-datalad_catalog-maint.yaml
+++ b/.github/workflows/test-datalad_catalog-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_catalog extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-catalog[devel,test,tests]

--- a/.github/workflows/test-datalad_catalog-master.yaml
+++ b/.github/workflows/test-datalad_catalog-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_catalog extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-catalog[devel,test,tests]

--- a/.github/workflows/test-datalad_container-maint.yaml
+++ b/.github/workflows/test-datalad_container-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_container extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-container[devel,test,tests]

--- a/.github/workflows/test-datalad_container-master.yaml
+++ b/.github/workflows/test-datalad_container-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_container extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-container[devel,test,tests]

--- a/.github/workflows/test-datalad_crawler-maint.yaml
+++ b/.github/workflows/test-datalad_crawler-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_crawler extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-crawler[devel,test,tests]

--- a/.github/workflows/test-datalad_crawler-master.yaml
+++ b/.github/workflows/test-datalad_crawler-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_crawler extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-crawler[devel,test,tests]

--- a/.github/workflows/test-datalad_dataverse-maint.yaml
+++ b/.github/workflows/test-datalad_dataverse-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_dataverse extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-dataverse[devel,test,tests]

--- a/.github/workflows/test-datalad_dataverse-master.yaml
+++ b/.github/workflows/test-datalad_dataverse-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_dataverse extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-dataverse[devel,test,tests]

--- a/.github/workflows/test-datalad_deprecated-maint.yaml
+++ b/.github/workflows/test-datalad_deprecated-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_deprecated extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-deprecated[devel,test,tests]

--- a/.github/workflows/test-datalad_deprecated-master.yaml
+++ b/.github/workflows/test-datalad_deprecated-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_deprecated extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-deprecated[devel,test,tests]

--- a/.github/workflows/test-datalad_fuse-maint.yaml
+++ b/.github/workflows/test-datalad_fuse-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_fuse extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-fuse[devel,test,tests]

--- a/.github/workflows/test-datalad_fuse-master.yaml
+++ b/.github/workflows/test-datalad_fuse-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_fuse extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-fuse[devel,test,tests]

--- a/.github/workflows/test-datalad_metalad-maint.yaml
+++ b/.github/workflows/test-datalad_metalad-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_metalad extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-metalad[devel,test,tests]

--- a/.github/workflows/test-datalad_metalad-master.yaml
+++ b/.github/workflows/test-datalad_metalad-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_metalad extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-metalad[devel,test,tests]

--- a/.github/workflows/test-datalad_neuroimaging-maint.yaml
+++ b/.github/workflows/test-datalad_neuroimaging-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_neuroimaging extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-neuroimaging[devel,test,tests]

--- a/.github/workflows/test-datalad_neuroimaging-master.yaml
+++ b/.github/workflows/test-datalad_neuroimaging-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_neuroimaging extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-neuroimaging[devel,test,tests]

--- a/.github/workflows/test-datalad_next-maint.yaml
+++ b/.github/workflows/test-datalad_next-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_next extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-next[devel,test,tests]

--- a/.github/workflows/test-datalad_next-master.yaml
+++ b/.github/workflows/test-datalad_next-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_next extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-next[devel,test,tests]

--- a/.github/workflows/test-datalad_osf-maint.yaml
+++ b/.github/workflows/test-datalad_osf-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_osf extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-osf[devel,test,tests]

--- a/.github/workflows/test-datalad_osf-master.yaml
+++ b/.github/workflows/test-datalad_osf-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_osf extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-osf[devel,test,tests]

--- a/.github/workflows/test-datalad_ukbiobank-maint.yaml
+++ b/.github/workflows/test-datalad_ukbiobank-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_ukbiobank extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-ukbiobank[devel,test,tests]

--- a/.github/workflows/test-datalad_ukbiobank-master.yaml
+++ b/.github/workflows/test-datalad_ukbiobank-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_ukbiobank extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-ukbiobank[devel,test,tests]

--- a/.github/workflows/test-datalad_xnat-maint.yaml
+++ b/.github/workflows/test-datalad_xnat-maint.yaml
@@ -28,6 +28,12 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
+
       fail-fast: false
 
     steps:
@@ -63,6 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/maint.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_xnat extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-xnat[devel,test,tests]

--- a/.github/workflows/test-datalad_xnat-master.yaml
+++ b/.github/workflows/test-datalad_xnat-master.yaml
@@ -28,6 +28,8 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain]
+
       fail-fast: false
 
     steps:
@@ -63,6 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/master.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install datalad_xnat extension from PyPI ([devel,test,tests])
       run: |
         pip install datalad-xnat[devel,test,tests]

--- a/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
@@ -28,6 +28,7 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
+        datalad-install-scenario: [plain, with-datalad-next-release]
       fail-fast: false
 
     steps:
@@ -63,6 +64,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/{{ datalad_branch }}.zip
+    - name: Install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release' && datalad_branch == 'maint'
+      run: pip install datalad-next
     - name: Install {{ extension.name }} extension from PyPI ([devel,test,tests])
       run: |
         pip install {{ extension.pypi }}[devel,test,tests]

--- a/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
@@ -28,7 +28,10 @@ jobs:
         # name mimics the one in .travis.yml for datalad build introduced in
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
-        datalad-install-scenario: [plain, with-datalad-next-release]
+        datalad-install-scenario: [plain]
+        include:
+          - annex-install-scenario: neurodebian
+            datalad-install-scenario: with-datalad-next-release
       fail-fast: false
 
     steps:
@@ -65,8 +68,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/{{ datalad_branch }}.zip
     - name: Install datalad-next
-      if: matrix.datalad-install-scenario == 'with-datalad-next-release' && datalad_branch == 'maint'
-      run: pip install datalad-next
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release' && {{ datalad_branch }} == 'maint'
+      run: |
+        pip install datalad-next
+        git config --global --add datalad.extensions.load next
     - name: Install {{ extension.name }} extension from PyPI ([devel,test,tests])
       run: |
         pip install {{ extension.pypi }}[devel,test,tests]

--- a/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
@@ -29,9 +29,11 @@ jobs:
         # https://github.com/datalad/datalad/pull/4640
         annex-install-scenario: [neurodebian, datalad-git-annex-latest]
         datalad-install-scenario: [plain]
+{% if datalad_branch == 'maint' %}
         include:
           - annex-install-scenario: neurodebian
             datalad-install-scenario: with-datalad-next-release
+{% endif %}
       fail-fast: false
 
     steps:
@@ -67,13 +69,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/{{ datalad_branch }}.zip
-{% if datalad_branch == 'maint' %}
     - name: Install datalad-next
       if: matrix.datalad-install-scenario == 'with-datalad-next-release'
       run: |
         pip install datalad-next
         git config --global --add datalad.extensions.load next
-{% endif %}
     - name: Install {{ extension.name }} extension from PyPI ([devel,test,tests])
       run: |
         pip install {{ extension.pypi }}[devel,test,tests]

--- a/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
@@ -67,11 +67,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install https://github.com/datalad/datalad/archive/{{ datalad_branch }}.zip
+{% if datalad_branch == 'maint' %}
     - name: Install datalad-next
-      if: matrix.datalad-install-scenario == 'with-datalad-next-release' && {{ datalad_branch }} == 'maint'
+      if: matrix.datalad-install-scenario == 'with-datalad-next-release'
       run: |
         pip install datalad-next
         git config --global --add datalad.extensions.load next
+{% endif %}
     - name: Install {{ extension.name }} extension from PyPI ([devel,test,tests])
       run: |
         pip install {{ extension.pypi }}[devel,test,tests]


### PR DESCRIPTION
ATM added testing only against release of next and only against datalad-maint.  WDYT @mih -- should I change to test against `master` version of datalad-next?

TODOs
- [ ] add to the README.md table