### PR TITLE
Upgrade to use python 3.11 instead of 3.9

### DIFF
--- a/.github/workflows/test-datalad_catalog-maint.yaml
+++ b/.github/workflows/test-datalad_catalog-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_catalog-master.yaml
+++ b/.github/workflows/test-datalad_catalog-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_container-maint.yaml
+++ b/.github/workflows/test-datalad_container-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_container-master.yaml
+++ b/.github/workflows/test-datalad_container-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_dataverse-maint.yaml
+++ b/.github/workflows/test-datalad_dataverse-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_dataverse-master.yaml
+++ b/.github/workflows/test-datalad_dataverse-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_deprecated-maint.yaml
+++ b/.github/workflows/test-datalad_deprecated-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_deprecated-master.yaml
+++ b/.github/workflows/test-datalad_deprecated-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_fuse-maint.yaml
+++ b/.github/workflows/test-datalad_fuse-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_fuse-master.yaml
+++ b/.github/workflows/test-datalad_fuse-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_metalad-maint.yaml
+++ b/.github/workflows/test-datalad_metalad-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_metalad-master.yaml
+++ b/.github/workflows/test-datalad_metalad-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_neuroimaging-maint.yaml
+++ b/.github/workflows/test-datalad_neuroimaging-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_neuroimaging-master.yaml
+++ b/.github/workflows/test-datalad_neuroimaging-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_next-maint.yaml
+++ b/.github/workflows/test-datalad_next-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_next-master.yaml
+++ b/.github/workflows/test-datalad_next-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_osf-maint.yaml
+++ b/.github/workflows/test-datalad_osf-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_osf-master.yaml
+++ b/.github/workflows/test-datalad_osf-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_ukbiobank-maint.yaml
+++ b/.github/workflows/test-datalad_ukbiobank-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_ukbiobank-master.yaml
+++ b/.github/workflows/test-datalad_ukbiobank-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_xnat-maint.yaml
+++ b/.github/workflows/test-datalad_xnat-maint.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (maint)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-datalad_xnat-master.yaml
+++ b/.github/workflows/test-datalad_xnat-master.yaml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad (master)
       run: |
         python -m pip install --upgrade pip

--- a/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
+++ b/templates/.github/workflows/test-{{extension.name}}-{{datalad_branch}}.yaml
@@ -62,10 +62,10 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install DataLad ({{ datalad_branch }})
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
We had prior attempt to upgrade in
- #128


<details>
<summary>
and now we got failing build installs so may be we get it better with 3.11
</summary>

e.g. https://github.com/datalad/datalad-extensions/actions/runs/15035390748/job/42256079524#step:6:55

```
Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages (25.1.1)
Collecting https://github.com/datalad/datalad/archive/master.zip
  Downloading https://github.com/datalad/datalad/archive/master.zip
     | 1.7 MB 10.0 MB/s 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [19 lines of output]
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
        File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line [14](https://github.com/datalad/datalad-extensions/actions/runs/15035390748/job/42256079524#step:6:15)3, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-d466csg3/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-d466csg3/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-d466csg3/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-d466csg3/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 3[17](https://github.com/datalad/datalad-extensions/actions/runs/15035390748/job/42256079524#step:6:18), in run_setup
          exec(code, locals())
        File "<string>", line 19, in <module>
        File "/tmp/pip-req-build-pc51ylbw/_datalad_build_support/setup.py", line 25, in <module>
          from setuptools import (
      ImportError: cannot import name 'DistutilsOptionError' from 'setuptools' (/tmp/pip-build-env-d466csg3/overlay/lib/python3.9/site-packages/setuptools/__init__.py)
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.
```

</details>